### PR TITLE
rustfmt, clippy, using our fork of capnproto-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,13 @@ dependencies = [
 
 [[package]]
 name = "capnp"
-version = "0.14.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
+version = "0.18.0-alpha"
+source = "git+https://github.com/Fundament-Software/capnproto-rust#2226ee6e377cc31c73de2d2ddb1124bcdbb64f9f"
 
 [[package]]
 name = "capnp-futures"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9821801cc6f199a9d9c3c793504e800c797b536d2befddaffb15144e40a6e63a"
+version = "0.18.0-alpha"
+source = "git+https://github.com/Fundament-Software/capnproto-rust#2226ee6e377cc31c73de2d2ddb1124bcdbb64f9f"
 dependencies = [
  "capnp",
  "futures",
@@ -308,7 +306,7 @@ dependencies = [
 [[package]]
 name = "capnp-import"
 version = "0.2.0"
-source = "git+https://github.com/Fundament-Software/capnp-import#6b9831f354acb15074ed243b8b77eb45bcccfe6a"
+source = "git+https://github.com/Fundament-Software/capnproto-rust#2226ee6e377cc31c73de2d2ddb1124bcdbb64f9f"
 dependencies = [
  "anyhow",
  "capnp",
@@ -329,9 +327,8 @@ dependencies = [
 
 [[package]]
 name = "capnp-rpc"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4f17f96f68f2c1168ed7105d9e5cb4a095a5bef3578aee0f9c0644b85ca95e"
+version = "0.18.0-alpha"
+source = "git+https://github.com/Fundament-Software/capnproto-rust#2226ee6e377cc31c73de2d2ddb1124bcdbb64f9f"
 dependencies = [
  "capnp",
  "capnp-futures",
@@ -340,9 +337,8 @@ dependencies = [
 
 [[package]]
 name = "capnpc"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc9f1dc84666d4ff007b1a16c8f97db80764a624625979be05d869bcff43aaa"
+version = "0.18.0-alpha"
+source = "git+https://github.com/Fundament-Software/capnproto-rust#2226ee6e377cc31c73de2d2ddb1124bcdbb64f9f"
 dependencies = [
  "capnp",
 ]
@@ -1152,7 +1148,6 @@ dependencies = [
 name = "keystone"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_fs",
  "async-trait",
  "atomic-counter",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,10 +21,10 @@ async-trait = "0.1.57"
 atomic-counter = "1.0"
 bytes = "1.4.0"
 cap-std = "0.26"
-capnp = "0.14.9"
-capnp-futures = "0.14"
-capnp-import = { git = "https://github.com/Fundament-Software/capnp-import" }
-capnp-rpc = "0.14"
+capnp = { git = "https://github.com/Fundament-Software/capnproto-rust" }
+capnp-futures = { git = "https://github.com/Fundament-Software/capnproto-rust" }
+capnp-import = { git = "https://github.com/Fundament-Software/capnproto-rust" }
+capnp-rpc = { git = "https://github.com/Fundament-Software/capnproto-rust" }
 chrono = "0.4"
 color-eyre = "0.6"
 couch_rs = "0.9"
@@ -44,7 +44,3 @@ url = "2.3.1"
 [dev-dependencies]
 predicates = "2.1"
 assert_fs = "1.0"
-
-[build-dependencies]
-anyhow = "1.*"
-capnp-import = { git = "https://github.com/Fundament-Software/capnp-import" }

--- a/core/src/couchdb.rs
+++ b/core/src/couchdb.rs
@@ -1,11 +1,11 @@
 use super::database;
-use eyre::Result;
 use async_trait::async_trait;
 use atomic_counter::{AtomicCounter, RelaxedCounter};
 use capnp_rpc::pry;
 use couch_rs::document::TypedCouchDocument;
 use couch_rs::types::document::DocumentId;
 use couch_rs::CouchDocument;
+use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -26,7 +26,7 @@ impl CouchDB {
         Ok(Self {
             client,
             rollover: RelaxedCounter::new(0),
-            log: log,
+            log,
         })
     }
 }

--- a/core/src/http/path.rs
+++ b/core/src/http/path.rs
@@ -443,7 +443,7 @@ mod tests {
         // Test that GET request fails
         let request = path_client.get_request();
         assert_eq!(
-            request.send().promise.await.err().map(|e| e.description),
+            request.send().promise.await.err().map(|e| e.extra),
             Some("GET is not on a whitelist and can't be executed".to_string())
         );
 

--- a/core/tests/http_test.rs
+++ b/core/tests/http_test.rs
@@ -286,7 +286,7 @@ async fn allowlist_test() -> eyre::Result<(), capnp::Error> {
     // GET request fails
     let request = client.get_request();
     assert_eq!(
-        request.send().promise.await.err().map(|e| e.description),
+        request.send().promise.await.err().map(|e| e.extra),
         Some("GET is not on a whitelist and can't be executed".to_string())
     );
 
@@ -301,14 +301,14 @@ async fn allowlist_test() -> eyre::Result<(), capnp::Error> {
     // GET request fails
     let request = client.get_request();
     assert_eq!(
-        request.send().promise.await.err().map(|e| e.description),
+        request.send().promise.await.err().map(|e| e.extra),
         Some("GET is not on a whitelist and can't be executed".to_string())
     );
 
     // DELETE request now doesn't work
     let request = client.delete_request();
     assert_eq!(
-        request.send().promise.await.err().map(|e| e.description),
+        request.send().promise.await.err().map(|e| e.extra),
         Some("DELETE is not on a whitelist and can't be executed".to_string())
     );
 


### PR DESCRIPTION
Updated to point at our fork of capnproto-rust. Version 0.18-alpha renames `description` field of `capnp::Error` to `extra`, so updated that too, making it compile. Also removed redundant section from `Cargo.toml`, some rustfmt changes due to saving and did a simple substitution of `log: log` -> `log`.

I didn't point to specific commit or branch of `Fundament-Software/capnproto-rust`, since that will probably change very soon, but it makes sense to do that.

Also the first time I ran `cargo test`, one of the tests didn't pass - in particular test `protocol_relative_url_path` failed due to receiving a different http code - 502 (Bad Gateway) instead of 404. It passed every other time, so it might've been a local problem, but it's something to keep in mind.