### PR TITLE
Add Makefile and Justfile to make it easier to run integration tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,12 @@
+set windows-shell := ["powershell", "-c"]
+set shell := ["bash"]
+set export
+
+# if unset default CC to clang on Linux because capstone is incompatible with GCC
+CC := env("CC", if os() == "linux" { "clang" } else { "" })
+
+test: build
+    cargo test --workspace --all
+    
+build:
+    cargo build --workspace --all

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test: build
+	cargo test --workspace --all
+
+build:
+	CC="$${CC:-clang}" cargo build --workspace --all
+
+.PHONY: build test


### PR DESCRIPTION
`cargo test` alone won't ensure the binaries used in integration tests exist. Adding make/just support makes it easier to do the right thing.