### PR TITLE
Update hyper to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,9 +197,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -217,8 +223,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1063,7 +1069,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.4.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.4.0",
  "slab",
  "tokio",
@@ -1160,13 +1185,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1198,9 +1257,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1213,12 +1272,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1226,15 +1306,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1397,8 +1500,10 @@ dependencies = [
  "eyre",
  "futures-util",
  "hello-world",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-tls",
+ "hyper-util",
  "indirect-world",
  "keystone-build",
  "keystone-util",
@@ -2581,10 +2686,10 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +278,29 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "binfarce"
@@ -475,7 +525,18 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -483,6 +544,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -523,6 +595,15 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -832,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,21 +1012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1030,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1033,6 +1111,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -1174,6 +1258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1386,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,22 +1415,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1476,6 +1573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "keystone"
 version = "0.1.0"
 dependencies = [
@@ -1502,7 +1608,7 @@ dependencies = [
  "hello-world",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "indirect-world",
  "keystone-build",
@@ -1576,6 +1682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1698,16 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "libredox"
@@ -1718,21 +1840,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
+name = "mirai-annotations"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "nom"
@@ -1877,48 +1988,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "overload"
@@ -1954,6 +2027,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2068,6 +2147,16 @@ checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2215,6 +2304,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2358,61 @@ dependencies = [
  "linux-raw-sys",
  "once_cell",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2412,6 +2577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stateful"
 version = "0.1.0"
 dependencies = [
@@ -2438,10 +2609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "syn"
-version = "2.0.75"
+name = "subtle"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2607,12 +2784,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2852,6 +3030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +3136,27 @@ dependencies = [
  "regex",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3106,3 +3311,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,8 +40,10 @@ capstone-rpc.workspace = true
 capstone-macros.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-hyper = { version = "0.14", features = ["full"] }
-hyper-tls = "0.5"
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
+http-body-util = "0.1"
+hyper-tls = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 tokio.workspace = true
 tokio-util.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,8 +42,8 @@ color-eyre.workspace = true
 eyre.workspace = true
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
+hyper-rustls = { version = "0.27.3", features = ["webpki-roots", "http2"] }
 http-body-util = "0.1"
-hyper-tls = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 tokio.workspace = true
 tokio-util.workspace = true

--- a/core/src/http/domain.rs
+++ b/core/src/http/domain.rs
@@ -2,7 +2,7 @@ use super::path::PathImpl;
 use super::{Domain, Path};
 use capnp_macros::capnproto_rpc;
 use hyper::http::uri::Authority;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient};
 
 #[derive(Clone)]

--- a/core/src/http/domain.rs
+++ b/core/src/http/domain.rs
@@ -1,21 +1,21 @@
 use super::path::PathImpl;
 use super::{Domain, Path};
 use capnp_macros::capnproto_rpc;
-use hyper::client::HttpConnector;
 use hyper::http::uri::Authority;
 use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient};
 
 #[derive(Clone)]
 pub struct DomainImpl {
     domain_name: Authority,
-    https_client: hyper::Client<HttpsConnector<HttpConnector>>,
+    https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
     modifiable: bool,
 }
 
 impl DomainImpl {
     pub fn new<A: TryInto<Authority>>(
         domain_name: A,
-        https_client: hyper::Client<HttpsConnector<HttpConnector>>,
+        https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
     ) -> Result<Self, capnp::Error> {
         Ok(DomainImpl {
             https_client,

--- a/core/src/http/https.rs
+++ b/core/src/http/https.rs
@@ -1,7 +1,7 @@
 use super::domain::DomainImpl;
 use super::{Domain, Https};
 use capnp_macros::capnproto_rpc;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient};
 use hyper_util::rt::TokioExecutor;
 
@@ -11,7 +11,11 @@ pub struct HttpsImpl {
 
 impl HttpsImpl {
     pub fn new() -> Self {
-        let connector = HttpsConnector::new();
+        let connector = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_all_versions()
+            .build();
         let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         HttpsImpl { https_client }
     }

--- a/core/src/http/https.rs
+++ b/core/src/http/https.rs
@@ -1,17 +1,18 @@
 use super::domain::DomainImpl;
 use super::{Domain, Https};
 use capnp_macros::capnproto_rpc;
-use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient};
+use hyper_util::rt::TokioExecutor;
 
 pub struct HttpsImpl {
-    https_client: hyper::Client<HttpsConnector<HttpConnector>>,
+    https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
 }
 
 impl HttpsImpl {
     pub fn new() -> Self {
         let connector = HttpsConnector::new();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(connector);
+        let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         HttpsImpl { https_client }
     }
 }

--- a/core/src/http/path.rs
+++ b/core/src/http/path.rs
@@ -1,16 +1,9 @@
 use super::Path;
 use capnp_macros::capnproto_rpc;
 use http_body_util::BodyExt;
-use hyper::{
-    http::uri::Authority,
-    HeaderMap,
-};
+use hyper::{http::uri::Authority, HeaderMap};
 use hyper_tls::HttpsConnector;
-use hyper_util::client::legacy::{
-    connect::HttpConnector,
-    Client as HttpClient,
-    ResponseFuture
-};
+use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient, ResponseFuture};
 
 use Path::HttpVerb;
 
@@ -143,7 +136,9 @@ async fn http_request_promise(
                 .into(),
         );
     }
-    let body_bytes: bytes::Bytes = response.into_body().collect()
+    let body_bytes: bytes::Bytes = response
+        .into_body()
+        .collect()
         .await
         .map_err(|err| capnp::Error::failed(err.to_string()))?
         .to_bytes();

--- a/core/src/http/path.rs
+++ b/core/src/http/path.rs
@@ -1,11 +1,17 @@
 use super::Path;
 use capnp_macros::capnproto_rpc;
+use http_body_util::BodyExt;
 use hyper::{
-    client::{HttpConnector, ResponseFuture},
     http::uri::Authority,
     HeaderMap,
 };
 use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::{
+    connect::HttpConnector,
+    Client as HttpClient,
+    ResponseFuture
+};
+
 use Path::HttpVerb;
 
 impl std::fmt::Display for Path::HttpVerb {
@@ -25,7 +31,7 @@ impl std::fmt::Display for Path::HttpVerb {
 
 #[derive(Clone)]
 pub struct PathImpl {
-    https_client: hyper::Client<HttpsConnector<HttpConnector>>,
+    https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
     query: Vec<(String, String)>,
     path_list: Vec<String>,
     headers: HeaderMap,
@@ -40,7 +46,7 @@ impl PathImpl {
     pub fn new<A: TryInto<Authority>, S: Into<Vec<String>>>(
         authority: A,
         path_list: S,
-        https_client: hyper::Client<HttpsConnector<HttpConnector>>,
+        https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
     ) -> Result<Self, capnp::Error> {
         let verb_whitelist = vec![
             HttpVerb::Get,
@@ -99,10 +105,10 @@ impl PathImpl {
             request_builder = request_builder.header(key, value);
         }
 
-        let request_body: hyper::Body = match body {
-            Some(_) if has_empty_body => hyper::Body::empty(),
+        let request_body: String = match body {
+            Some(_) if has_empty_body => String::new(),
             Some(body) => body.into(),
-            None => hyper::Body::empty(),
+            None => String::new(),
         };
 
         let request = request_builder
@@ -137,9 +143,10 @@ async fn http_request_promise(
                 .into(),
         );
     }
-    let body_bytes = hyper::body::to_bytes(response.into_body())
+    let body_bytes: bytes::Bytes = response.into_body().collect()
         .await
-        .map_err(|err| capnp::Error::failed(err.to_string()))?;
+        .map_err(|err| capnp::Error::failed(err.to_string()))?
+        .to_bytes();
     let body = String::from_utf8(body_bytes.to_vec()).map_err(|_| {
         capnp::Error::failed("Couldn't convert response body to utf8 String".to_string())
     })?;
@@ -297,11 +304,12 @@ impl Path::Server for PathImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyper_util::rt::TokioExecutor;
 
     #[tokio::test]
     async fn get_test() -> capnp::Result<()> {
         let connector = HttpsConnector::new();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(connector);
+        let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client =
             capnp_rpc::new_client(PathImpl::new("httpbin.org", vec!["".into()], https_client)?);
 
@@ -331,7 +339,7 @@ mod tests {
     async fn whitelist_test() -> capnp::Result<()> {
         // Set url as example.org
         let connector = HttpsConnector::new();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(connector);
+        let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client =
             capnp_rpc::new_client(PathImpl::new("example.org", vec!["".into()], https_client)?);
 
@@ -369,7 +377,7 @@ mod tests {
     #[tokio::test]
     async fn post_test() -> capnp::Result<()> {
         let connector = HttpsConnector::new();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(connector);
+        let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client = capnp_rpc::new_client(PathImpl::new(
             "httpbin.org",
             vec!["post".into()],
@@ -428,7 +436,7 @@ mod tests {
     async fn header_test() -> capnp::Result<()> {
         // Current way to run it and see results: cargo test -- --nocapture
         let connector = HttpsConnector::new();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(connector);
+        let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client = capnp_rpc::new_client(PathImpl::new(
             "httpbin.org",
             vec!["headers".into()],

--- a/core/src/http/path.rs
+++ b/core/src/http/path.rs
@@ -2,7 +2,7 @@ use super::Path;
 use capnp_macros::capnproto_rpc;
 use http_body_util::BodyExt;
 use hyper::{http::uri::Authority, HeaderMap};
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient, ResponseFuture};
 
 use Path::HttpVerb;
@@ -303,7 +303,12 @@ mod tests {
 
     #[tokio::test]
     async fn get_test() -> capnp::Result<()> {
-        let connector = HttpsConnector::new();
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+
         let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client =
             capnp_rpc::new_client(PathImpl::new("httpbin.org", vec!["".into()], https_client)?);
@@ -333,7 +338,12 @@ mod tests {
     #[tokio::test]
     async fn whitelist_test() -> capnp::Result<()> {
         // Set url as example.org
-        let connector = HttpsConnector::new();
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+
         let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client =
             capnp_rpc::new_client(PathImpl::new("example.org", vec!["".into()], https_client)?);
@@ -371,7 +381,12 @@ mod tests {
 
     #[tokio::test]
     async fn post_test() -> capnp::Result<()> {
-        let connector = HttpsConnector::new();
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+
         let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client = capnp_rpc::new_client(PathImpl::new(
             "httpbin.org",
@@ -430,7 +445,12 @@ mod tests {
     #[tokio::test]
     async fn header_test() -> capnp::Result<()> {
         // Current way to run it and see results: cargo test -- --nocapture
-        let connector = HttpsConnector::new();
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+
         let https_client = HttpClient::builder(TokioExecutor::new()).build::<_, String>(connector);
         let mut path_client: Path::Client = capnp_rpc::new_client(PathImpl::new(
             "httpbin.org",


### PR DESCRIPTION
Used legacy Cient from hyper-util, since it maintains compatibility with hyper-tls, to allow https connections. 
Otherwise we'd need to find another suitable TLS implementation that implements Tokio's or hyper's IO traits