### PR TITLE
core: add path to read error in toml_to_config

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -11,7 +11,7 @@ use capnp::{
     dynamic_struct, dynamic_value, introspect::TypeVariant, schema::DynamicSchema, schema_capnp,
     traits::HasTypeId,
 };
-use eyre::Result;
+use eyre::{Context, Result};
 use toml::{value::Offset, Table, Value};
 
 fn expr_recurse(val: &Value, exprs: &mut HashMap<*const Value, u32>) {
@@ -261,7 +261,8 @@ where
 
             message_from_file(schemafile)?
         } else {
-            let file_contents = std::fs::read(path)?;
+            let file_contents = std::fs::read(&path)
+                .with_context(|| format!("toml_to_config failed to read {}", path.display()))?;
 
             let binary = crate::binary_embed::load_deps_from_binary(&file_contents)?;
             let bufread = BufReader::new(binary);


### PR DESCRIPTION
Without this the error for a missing file is unhelpful and doesn't include the path.

```
Error: 
   0: No such file or directory (os error 2)

Location:
   core/src/config.rs:264
```