### PR TITLE
Justfile: add example target which runs example.os.toml

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 set windows-shell := ["powershell", "-c"]
-set shell := ["bash"]
+set shell := ["/usr/bin/env", "bash", "-c"]
 set export
 
 # if unset default CC to clang on Linux because capstone is incompatible with GCC

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,9 @@ CC := env("CC", if os() == "linux" { "clang" } else { "" })
 
 test: build
     cargo test --workspace --all
-    
+
 build:
     cargo build --workspace --all
+
+example: build
+    cargo run --features="binary-deps" --bin keystone -- session -i -t ./examples/example.{{os()}}.toml

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             rust-custom-toolchain
 
             cargo-edit
+            just
           ];
 
           # fetch with cli instead of native


### PR DESCRIPTION
Makes (correctly) running the example more convenient.