### PR TITLE
Rc Refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "async-byte-channel"
 version = "0.0.1"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "tokio",
 ]
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "serde",
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "caplog"
 version = "0.1.0"
-source = "git+https://github.com/Fundament-Software/caplog#3c17aadb1865472beca3e600b97841089d859cad"
+source = "git+https://github.com/Fundament-Software/caplog#09e7cbe436b803c2d03391357cdbfdd4aad97b64"
 dependencies = [
  "bitfield-struct",
  "capstone",
@@ -334,7 +334,7 @@ dependencies = [
  "num",
  "rand",
  "tempfile",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
 ]
 
@@ -353,7 +353,7 @@ dependencies = [
 [[package]]
 name = "capstone"
 version = "0.18.0"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "embedded-io",
  "flurry",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "capstone-futures"
 version = "0.18.0"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "capstone",
  "futures-util",
@@ -374,7 +374,7 @@ dependencies = [
 [[package]]
 name = "capstone-gen"
 version = "0.18.0"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "capnp-sys",
  "capstone",
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "capstone-macros"
 version = "0.18.0"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "capstone",
  "capstone-gen",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "capstone-rpc"
 version = "0.18.0"
-source = "git+https://github.com/Fundament-Software/capstone-rs#98f72facf8eaa093d35ec653474cebbe71e03152"
+source = "git+https://github.com/Fundament-Software/capstone-rs#497900e7875ff793113aa779f34d5940ce4f3f67"
 dependencies = [
  "capstone",
  "capstone-futures",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "shlex",
 ]
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -776,9 +776,9 @@ checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
 
 [[package]]
 name = "cxx"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e1ec88093d2abd9cf1b09ffd979136b8e922bf31cad966a8fe0d73233112ef"
+checksum = "a5a32d755fe20281b46118ee4b507233311fb7a48a0cfd42f554b93640521a2f"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa390d956ee7ccb41aeed7ed7856ab3ffb4fc587e7216be7e0f83e949b4e6c"
+checksum = "11645536ada5d1c8804312cbffc9ab950f2216154de431de930da47ca6955199"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23bfff654d6227cbc83de8e059d2f8678ede5fc3a6c5a35d5c379983cc61e6"
+checksum = "ebcc9c78e3c7289665aab921a2b394eaffe8bdb369aa18d81ffc0f534fd49385"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -817,15 +817,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c01b36e22051bc6928a78583f1621abaaf7621561c2ada1b00f7878fbe2caa"
+checksum = "3a22a87bd9e78d7204d793261470a4c9d585154fddd251828d8aefbb5f74c3bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e14013136fac689345d17b9a6df55977251f11d333c0a571e8d963b55e1f95"
+checksum = "1dfdb020ff8787c5daf6e0dca743005cc8782868faeadfbabb8824ede5cb1c72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -2600,27 +2600,27 @@ checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2914,11 +2914,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -2934,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/src/cap_std_capnproto.rs
+++ b/core/src/cap_std_capnproto.rs
@@ -1344,7 +1344,7 @@ pub mod tests {
     #[tokio::test]
     async fn create_dir_all_canonicalize_test() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();
@@ -1378,7 +1378,7 @@ pub mod tests {
     async fn test_create_write_getmetadata() -> eyre::Result<()> {
         //use ambient authority to open a dir, create a file(Or open it in write mode if it already exists), open a bytestream, use the bytestream to write some bytes, get file metadata
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();
@@ -1437,7 +1437,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_home_dir() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let home_dir_request = ambient_authority.user_dirs_home_dir_request();
         let _home_dir = home_dir_request.send().promise.await?.get()?.get_dir()?;
@@ -1447,7 +1447,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_user_dirs() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let audio_dir_request = ambient_authority.user_dirs_audio_dir_request();
         let _audio_dir = audio_dir_request.send().promise.await?.get()?.get_dir()?;
@@ -1500,7 +1500,7 @@ pub mod tests {
     async fn test_project_dirs() -> eyre::Result<()> {
         //TODO maybe create some form of generic "dir" test
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let mut project_dirs_from_request = ambient_authority.project_dirs_from_request();
         let mut project_dirs_builder = project_dirs_from_request.get();
@@ -1543,7 +1543,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_system_clock() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let system_clock_request = ambient_authority.system_clock_new_request();
         let system_clock = system_clock_request
@@ -1594,7 +1594,7 @@ pub mod tests {
         std::fs::create_dir_all(path)?;
 
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let mut path = std::env::temp_dir();
@@ -1760,7 +1760,7 @@ pub mod tests {
         writer.flush()?;
 
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client(RefCell::new(AmbientAuthorityImpl::new()));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();

--- a/core/src/cap_std_capnproto.rs
+++ b/core/src/cap_std_capnproto.rs
@@ -1344,7 +1344,7 @@ pub mod tests {
     #[tokio::test]
     async fn create_dir_all_canonicalize_test() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();
@@ -1378,7 +1378,7 @@ pub mod tests {
     async fn test_create_write_getmetadata() -> eyre::Result<()> {
         //use ambient authority to open a dir, create a file(Or open it in write mode if it already exists), open a bytestream, use the bytestream to write some bytes, get file metadata
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();
@@ -1437,7 +1437,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_home_dir() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let home_dir_request = ambient_authority.user_dirs_home_dir_request();
         let _home_dir = home_dir_request.send().promise.await?.get()?.get_dir()?;
@@ -1447,7 +1447,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_user_dirs() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let audio_dir_request = ambient_authority.user_dirs_audio_dir_request();
         let _audio_dir = audio_dir_request.send().promise.await?.get()?.get_dir()?;
@@ -1500,7 +1500,7 @@ pub mod tests {
     async fn test_project_dirs() -> eyre::Result<()> {
         //TODO maybe create some form of generic "dir" test
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let mut project_dirs_from_request = ambient_authority.project_dirs_from_request();
         let mut project_dirs_builder = project_dirs_from_request.get();
@@ -1543,7 +1543,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_system_clock() -> eyre::Result<()> {
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let system_clock_request = ambient_authority.system_clock_new_request();
         let system_clock = system_clock_request
@@ -1594,7 +1594,7 @@ pub mod tests {
         std::fs::create_dir_all(path)?;
 
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let mut path = std::env::temp_dir();
@@ -1760,7 +1760,7 @@ pub mod tests {
         writer.flush()?;
 
         let ambient_authority: ambient_authority::Client =
-            capnp_rpc::new_client(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
+            capnp_rpc::new_client_from_rc(Rc::new(RefCell::new(AmbientAuthorityImpl::new())));
 
         let mut open_ambient_request = ambient_authority.dir_open_ambient_request();
         let path = std::env::temp_dir();

--- a/core/src/cap_std_capnproto.rs
+++ b/core/src/cap_std_capnproto.rs
@@ -76,8 +76,8 @@ impl Default for AmbientAuthorityImpl {
 }
 
 #[capnproto_rpc(ambient_authority)]
-impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
-    async fn file_open_ambient(&self, path: Reader) {
+impl ambient_authority::Server for RefCell<AmbientAuthorityImpl> {
+    async fn file_open_ambient(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_file) = File::open_ambient(path, self.as_ref().borrow().authority) else {
             return Err(Error::failed(
@@ -86,10 +86,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_file(AmbientAuthorityImpl::new_file(self, _file));
+            .set_file(AmbientAuthorityImpl::new_file(&self, _file));
         Ok(())
     }
-    async fn file_create_ambient(&self, path: Reader) {
+    async fn file_create_ambient(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_file) = File::create_ambient(path, self.as_ref().borrow().authority) else {
             return Err(Error::failed(
@@ -98,10 +98,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_file(AmbientAuthorityImpl::new_file(self, _file));
+            .set_file(AmbientAuthorityImpl::new_file(&self, _file));
         Ok(())
     }
-    async fn file_open_ambient_with(&self, path: Reader, open_options: Reader) {
+    async fn file_open_ambient_with(self: Rc<Self>, path: Reader, open_options: Reader) {
         capnp_let!({read, write, append, truncate, create, create_new} = open_options);
         let mut options = OpenOptions::new();
         let path = path.to_str()?;
@@ -121,10 +121,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_file(AmbientAuthorityImpl::new_file(self, _file));
+            .set_file(AmbientAuthorityImpl::new_file(&self, _file));
         Ok(())
     }
-    async fn dir_open_ambient(&self, path: Reader) {
+    async fn dir_open_ambient(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_dir) = Dir::open_ambient_dir(path, self.as_ref().borrow().authority) else {
             return Err(Error::failed(
@@ -133,10 +133,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_result(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_result(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn dir_open_parent(&self, dir: Dir) {
+    async fn dir_open_parent(self: Rc<Self>, dir: Dir) {
         let Some(dir_impl) = self
             .as_ref()
             .borrow()
@@ -153,10 +153,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_result(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_result(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn dir_create_ambient_all(&self, path: Reader) {
+    async fn dir_create_ambient_all(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(()) = Dir::create_ambient_dir_all(path, self.as_ref().borrow().authority) else {
             return Err(Error::failed(
@@ -165,7 +165,7 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         Ok(())
     }
-    async fn monotonic_clock_new(&self) {
+    async fn monotonic_clock_new(self: Rc<Self>) {
         results
             .get()
             .set_clock(capnp_rpc::new_client(MonotonicClockImpl {
@@ -174,7 +174,7 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
             }));
         Ok(())
     }
-    async fn system_clock_new(&self) {
+    async fn system_clock_new(self: Rc<Self>) {
         results
             .get()
             .set_clock(capnp_rpc::new_client(SystemClockImpl {
@@ -183,7 +183,7 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         Ok(())
     }
     async fn project_dirs_from(
-        &self,
+        self: Rc<Self>,
         qualifier: Reader,
         organization: Reader,
         application: Reader,
@@ -204,7 +204,7 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
             }));
         Ok(())
     }
-    async fn user_dirs_home_dir(&self) {
+    async fn user_dirs_home_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -213,10 +213,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_audio_dir(&self) {
+    async fn user_dirs_audio_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -225,10 +225,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_desktop_dir(&self) {
+    async fn user_dirs_desktop_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -237,10 +237,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_document_dir(&self) {
+    async fn user_dirs_document_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -249,10 +249,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_download_dir(&self) {
+    async fn user_dirs_download_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -261,10 +261,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_font_dir(&self) {
+    async fn user_dirs_font_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -273,10 +273,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_picture_dir(&self) {
+    async fn user_dirs_picture_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -285,10 +285,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_public_dir(&self) {
+    async fn user_dirs_public_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -297,10 +297,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_template_dir(&self) {
+    async fn user_dirs_template_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -309,10 +309,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn user_dirs_video_dir(&self) {
+    async fn user_dirs_video_dir(self: Rc<Self>) {
         let Some(user_dirs) = UserDirs::new() else {
             return Err(Error::failed("No valid $HOME directory".into()));
         };
@@ -321,10 +321,10 @@ impl ambient_authority::Server for Rc<RefCell<AmbientAuthorityImpl>> {
         };
         results
             .get()
-            .set_dir(AmbientAuthorityImpl::new_dir(self, _dir));
+            .set_dir(AmbientAuthorityImpl::new_dir(&self, _dir));
         Ok(())
     }
-    async fn temp_dir_new(&self) {
+    async fn temp_dir_new(self: Rc<Self>) {
         let Ok(dir) = TempDir::new(self.as_ref().borrow().authority) else {
             return Err(Error::failed("Failed to create temp dir".into()));
         };
@@ -344,7 +344,7 @@ pub struct DirImpl {
 }
 #[capnproto_rpc(dir)]
 impl dir::Server for DirImpl {
-    async fn open(&self, path: Reader) {
+    async fn open(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_file) = self.dir.open(path) else {
             return Err(Error::failed("Failed to open file".into()));
@@ -354,7 +354,7 @@ impl dir::Server for DirImpl {
             .set_file(AmbientAuthorityImpl::new_file(&self.ambient, _file));
         Ok(())
     }
-    async fn open_with(&self, open_options: Reader, path: Reader) {
+    async fn open_with(self: Rc<Self>, open_options: Reader, path: Reader) {
         capnp_let!({read, write, append, truncate, create, create_new} = open_options);
         let mut options = OpenOptions::new();
         let path = path.to_str()?;
@@ -375,21 +375,21 @@ impl dir::Server for DirImpl {
             .set_file(AmbientAuthorityImpl::new_file(&self.ambient, _file));
         Ok(())
     }
-    async fn create_dir(&self, path: Reader) {
+    async fn create_dir(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_dir) = self.dir.create_dir(path) else {
             return Err(Error::failed("Failed to create dir".into()));
         };
         Ok(())
     }
-    async fn create_dir_all(&self, path: Reader) {
+    async fn create_dir_all(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_dir) = self.dir.create_dir_all(path) else {
             return Err(Error::failed("Failed to create dir(all)".into()));
         };
         Ok(())
     }
-    async fn create(&self, path: Reader) {
+    async fn create(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_file) = self.dir.create(path) else {
             return Err(Error::failed(
@@ -401,7 +401,7 @@ impl dir::Server for DirImpl {
             .set_file(AmbientAuthorityImpl::new_file(&self.ambient, _file));
         Ok(())
     }
-    async fn canonicalize(&self, path: Reader) {
+    async fn canonicalize(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(path_buf) = self.dir.canonicalize(path) else {
             return Err(Error::failed("Failed to canonicalize path".into()));
@@ -412,7 +412,7 @@ impl dir::Server for DirImpl {
         results.get().set_path_buf(_str.into());
         Ok(())
     }
-    async fn copy(&self, path_from: Reader, path_to: Reader, dir_to: Capability) {
+    async fn copy(self: Rc<Self>, path_from: Reader, path_to: Reader, dir_to: Capability) {
         let from = path_from.to_str()?;
         let to = path_to.to_str()?;
         let Some(dir_impl) = self
@@ -431,7 +431,7 @@ impl dir::Server for DirImpl {
         results.get().set_result(bytes);
         Ok(())
     }
-    async fn hard_link(&self, src_path: Reader, dst_path: Reader, dst_dir: Capability) {
+    async fn hard_link(self: Rc<Self>, src_path: Reader, dst_path: Reader, dst_dir: Capability) {
         let src = src_path.to_str()?;
         let dst = dst_path.to_str()?;
 
@@ -450,7 +450,7 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn metadata(&self, path: Reader) {
+    async fn metadata(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_metadata) = self.dir.metadata(path) else {
             return Err(Error::failed("Failed to get file metadata".into()));
@@ -462,7 +462,7 @@ impl dir::Server for DirImpl {
             }));
         Ok(())
     }
-    async fn dir_metadata(&self) {
+    async fn dir_metadata(self: Rc<Self>) {
         let Ok(_metadata) = self.dir.dir_metadata() else {
             return Err(Error::failed("Failed to get dir metadata".into()));
         };
@@ -473,7 +473,7 @@ impl dir::Server for DirImpl {
             }));
         Ok(())
     }
-    async fn entries(&self) {
+    async fn entries(self: Rc<Self>) {
         let Ok(mut _iter) = self.dir.entries() else {
             return Err(Error::failed("Failed to get dir entries".into()));
         };
@@ -483,7 +483,7 @@ impl dir::Server for DirImpl {
         }));
         Ok(())
     }
-    async fn read_dir(&self, path: Reader) {
+    async fn read_dir(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(mut _iter) = self.dir.read_dir(path) else {
             return Err(Error::failed("Failed to read dir".into()));
@@ -494,7 +494,7 @@ impl dir::Server for DirImpl {
         }));
         Ok(())
     }
-    async fn read(&self, path: Reader) {
+    async fn read(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(vec) = self.dir.read(path) else {
             return Err(Error::failed("Failed to read file".into()));
@@ -502,7 +502,7 @@ impl dir::Server for DirImpl {
         results.get().set_result(vec.as_slice());
         Ok(())
     }
-    async fn read_link(&self, path: Readers) {
+    async fn read_link(self: Rc<Self>, path: Readers) {
         let path = path.to_str()?;
         let Ok(_pathbuf) = self.dir.read_link(path) else {
             return Err(Error::failed("Failed to read link".into()));
@@ -513,7 +513,7 @@ impl dir::Server for DirImpl {
         results.get().set_result(_str.into());
         Ok(())
     }
-    async fn read_to_string(&self, path: Reader) {
+    async fn read_to_string(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(string) = self.dir.read_to_string(path) else {
             return Err(Error::failed("Failed to read file to string".into()));
@@ -521,21 +521,21 @@ impl dir::Server for DirImpl {
         results.get().set_result(string.as_str().into());
         Ok(())
     }
-    async fn remove_dir(&self, path: Reader) {
+    async fn remove_dir(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(()) = self.dir.remove_dir(path) else {
             return Err(Error::failed("Failed to remove dir".into()));
         };
         Ok(())
     }
-    async fn remove_dir_all(&self, path: Reader) {
+    async fn remove_dir_all(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(()) = self.dir.remove_dir_all(path) else {
             return Err(Error::failed("Failed to remove dir(all)".into()));
         };
         Ok(())
     }
-    async fn remove_open_dir(&self) {
+    async fn remove_open_dir(self: Rc<Self>) {
         //Original function consumes self so that it can't be used again, not sure how to do that with capnproto
         let Ok(this) = self.dir.try_clone() else {
             return Err(Error::failed("Failed to create an owned dir".into()));
@@ -545,7 +545,7 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn remove_open_dir_all(&self) {
+    async fn remove_open_dir_all(self: Rc<Self>) {
         //Original function consumes self so that it can't be used again, not sure how to do that with capnproto
         let Ok(this) = self.dir.try_clone() else {
             return Err(Error::failed("Failed to create an owned dir".into()));
@@ -555,14 +555,14 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn remove_file(&self, path: Reader) {
+    async fn remove_file(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(()) = self.dir.remove_file(path) else {
             return Err(Error::failed("Failed to remove file".into()));
         };
         Ok(())
     }
-    async fn rename(&self, from: Reader, to: Reader) {
+    async fn rename(self: Rc<Self>, from: Reader, to: Reader) {
         let from = from.to_str()?;
         let to = to.to_str()?;
         let this = &self.dir;
@@ -571,7 +571,7 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn set_readonly(&self, path: Reader, readonly: bool) {
+    async fn set_readonly(self: Rc<Self>, path: Reader, readonly: bool) {
         let path = path.to_str()?;
         let Ok(_meta) = self.dir.metadata(path) else {
             return Err(Error::failed(
@@ -587,7 +587,7 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn symlink_metadata(&self, path: Reader) {
+    async fn symlink_metadata(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_metadata) = self.dir.symlink_metadata(path) else {
             return Err(Error::failed("Failed to get symlink metadata".into()));
@@ -599,14 +599,14 @@ impl dir::Server for DirImpl {
             }));
         Ok(())
     }
-    async fn write(&self, path: Reader, contents: &[u8]) {
+    async fn write(self: Rc<Self>, path: Reader, contents: &[u8]) {
         let path = path.to_str()?;
         let Ok(()) = self.dir.write(path, contents) else {
             return Err(Error::failed("Failed to write to file".into()));
         };
         Ok(())
     }
-    async fn symlink(&self, original: Reader, link: Reader) {
+    async fn symlink(self: Rc<Self>, original: Reader, link: Reader) {
         let original = original.to_str()?;
         let link = link.to_str()?;
         #[cfg(target_os = "windows")]
@@ -619,13 +619,13 @@ impl dir::Server for DirImpl {
         };
         Ok(())
     }
-    async fn exists(&self, path: Reader) {
+    async fn exists(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let _results = self.dir.exists(path);
         results.get().set_result(_results);
         Ok(())
     }
-    async fn try_exists(&self, path: Reader) {
+    async fn try_exists(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let Ok(_results) = self.dir.try_exists(path) else {
             return Err(Error::failed("Failed to check if entity exists".into()));
@@ -633,20 +633,20 @@ impl dir::Server for DirImpl {
         results.get().set_result(_results);
         Ok(())
     }
-    async fn is_file(&self, path: Reader) {
+    async fn is_file(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let _results = self.dir.is_file(path);
         results.get().set_result(_results);
         Ok(())
     }
-    async fn is_dir(&self, path: Reader) {
+    async fn is_dir(self: Rc<Self>, path: Reader) {
         let path = path.to_str()?;
         let _results = self.dir.is_dir(path);
         results.get().set_result(_results);
         Ok(())
     }
 
-    async fn temp_dir_new_in(&self) {
+    async fn temp_dir_new_in(self: Rc<Self>) {
         let Ok(temp_dir) = cap_tempfile::TempDir::new_in(&self.dir) else {
             return Err(Error::failed("Failed to create temp dir".into()));
         };
@@ -658,7 +658,7 @@ impl dir::Server for DirImpl {
             }));
         Ok(())
     } /*
-      async fn temp_file_new(&self,  params: dir::TempFileNewParams, mut results: dir::TempFileNewresultss) {
+      async fn temp_file_new(self: Rc<Self>,  params: dir::TempFileNewParams, mut results: dir::TempFileNewresultss) {
 
           let dir_cap = pry!(params_reader.get_dir());
           let Some(underlying_dir) = DIR_SET.borrow().get_local_server_of_resolved(&dir_cap)) else {
@@ -671,7 +671,7 @@ impl dir::Server for DirImpl {
           results.get().set_temp_file(capnp_rpc::new_client(TempFileImpl{temp_file: Some(temp_file)}));
           Ok(())
       }*/
-    async fn temp_file_new_anonymous(&self) {
+    async fn temp_file_new_anonymous(self: Rc<Self>) {
         let Ok(file) = cap_tempfile::TempFile::new_anonymous(&self.dir) else {
             return Err(Error::failed("Failed to create anonymous temp file".into()));
         };
@@ -688,7 +688,7 @@ pub struct ReadDirImpl {
 }
 #[capnproto_rpc(read_dir)]
 impl read_dir::Server for ReadDirImpl {
-    async fn next(&self) {
+    async fn next(self: Rc<Self>) {
         let Some(_results) = self.iter.borrow_mut().next() else {
             return Err(Error::failed("Final entry reached".into()));
         };
@@ -712,7 +712,7 @@ pub struct DirEntryImpl {
 
 #[capnproto_rpc(dir_entry)]
 impl dir_entry::Server for DirEntryImpl {
-    async fn open(&self) {
+    async fn open(self: Rc<Self>) {
         let Ok(_file) = self.entry.open() else {
             return Err(Error::failed("Failed to open file for reading".into()));
         };
@@ -722,7 +722,7 @@ impl dir_entry::Server for DirEntryImpl {
         Ok(())
     }
 
-    async fn open_with(&self, open_options: Reader) {
+    async fn open_with(self: Rc<Self>, open_options: Reader) {
         capnp_let!({read, write, append, truncate, create, create_new} = open_options);
         let mut options = OpenOptions::new();
         options
@@ -742,7 +742,7 @@ impl dir_entry::Server for DirEntryImpl {
             .set_file(AmbientAuthorityImpl::new_file(&self.ambient, _file));
         Ok(())
     }
-    async fn open_dir(&self) {
+    async fn open_dir(self: Rc<Self>) {
         let Ok(_dir) = self.entry.open_dir() else {
             return Err(Error::failed("Failed to open the entry as a dir".into()));
         };
@@ -751,19 +751,19 @@ impl dir_entry::Server for DirEntryImpl {
             .set_dir(AmbientAuthorityImpl::new_dir(&self.ambient, _dir));
         Ok(())
     }
-    async fn remove_file(&self) {
+    async fn remove_file(self: Rc<Self>) {
         let Ok(()) = self.entry.remove_file() else {
             return Err(Error::failed("Failed to remove file".into()));
         };
         Ok(())
     }
-    async fn remove_dir(&self) {
+    async fn remove_dir(self: Rc<Self>) {
         let Ok(()) = self.entry.remove_dir() else {
             return Err(Error::failed("Failed to remove dir".into()));
         };
         Ok(())
     }
-    async fn metadata(&self) {
+    async fn metadata(self: Rc<Self>) {
         let Ok(_metadata) = self.entry.metadata() else {
             return Err(Error::failed("Failed to get file metadata".into()));
         };
@@ -774,7 +774,7 @@ impl dir_entry::Server for DirEntryImpl {
             }));
         Ok(())
     }
-    async fn file_type(&self) {
+    async fn file_type(self: Rc<Self>) {
         let Ok(_file_type) = self.entry.file_type() else {
             return Err(Error::failed("Failed to get file type".into()));
         };
@@ -790,7 +790,7 @@ impl dir_entry::Server for DirEntryImpl {
         results.get().set_type(_type);
         Ok(())
     }
-    async fn file_name(&self) {
+    async fn file_name(self: Rc<Self>) {
         let _name = self.entry.file_name();
         let Some(_name) = _name.to_str() else {
             return Err(Error::failed("File name not valid utf-8".into()));
@@ -806,7 +806,7 @@ pub struct FileImpl {
 }
 #[capnproto_rpc(file)]
 impl file::Server for FileImpl {
-    async fn sync_all(&self) {
+    async fn sync_all(self: Rc<Self>) {
         let Ok(()) = self.file.sync_all() else {
             return Err(Error::failed(
                 "Failed to sync os-internal metadata to disk".into(),
@@ -814,7 +814,7 @@ impl file::Server for FileImpl {
         };
         Ok(())
     }
-    async fn sync_data(&self) {
+    async fn sync_data(self: Rc<Self>) {
         let Ok(()) = self.file.sync_data() else {
             return Err(Error::failed(
                 "Failed to sync os-internal metadata to sync data".into(),
@@ -822,13 +822,13 @@ impl file::Server for FileImpl {
         };
         Ok(())
     }
-    async fn set_len(&self, size: u64) {
+    async fn set_len(self: Rc<Self>, size: u64) {
         let Ok(()) = self.file.set_len(size) else {
             return Err(Error::failed("Failed to update the size of file".into()));
         };
         Ok(())
     }
-    async fn metadata(&self) {
+    async fn metadata(self: Rc<Self>) {
         let Ok(_metadata) = self.file.metadata() else {
             return Err(Error::failed("Get file metadata".into()));
         };
@@ -839,7 +839,7 @@ impl file::Server for FileImpl {
             }));
         Ok(())
     }
-    async fn try_clone(&self) {
+    async fn try_clone(self: Rc<Self>) {
         let Ok(_file) = self.file.try_clone() else {
             return Err(Error::failed(
                 "Failed to sync os-internal metadata to sync data".into(),
@@ -850,7 +850,7 @@ impl file::Server for FileImpl {
             .set_cloned(AmbientAuthorityImpl::new_file(&self.ambient, _file));
         Ok(())
     }
-    async fn set_readonly(&self, readonly: bool) {
+    async fn set_readonly(self: Rc<Self>, readonly: bool) {
         let Ok(_meta) = self.file.metadata() else {
             return Err(Error::failed("Failed to get file's metadata".into()));
         };
@@ -864,7 +864,7 @@ impl file::Server for FileImpl {
         Ok(())
     }
 
-    async fn open(&self) {
+    async fn open(self: Rc<Self>) {
         let Ok(mut this) = self.file.try_clone() else {
             return Err(Error::failed("Get owned file".into()));
         };
@@ -884,7 +884,7 @@ pub struct MetadataImpl {
 }
 #[capnproto_rpc(metadata)]
 impl metadata::Server for MetadataImpl {
-    async fn file_type(&self) {
+    async fn file_type(self: Rc<Self>) {
         let _file_type = self.metadata.file_type();
         let _type: FileType = if _file_type.is_dir() {
             FileType::Dir
@@ -898,27 +898,27 @@ impl metadata::Server for MetadataImpl {
         results.get().set_file_type(_type);
         Ok(())
     }
-    async fn is_dir(&self) {
+    async fn is_dir(self: Rc<Self>) {
         let _results = self.metadata.is_dir();
         results.get().set_result(_results);
         Ok(())
     }
-    async fn is_file(&self) {
+    async fn is_file(self: Rc<Self>) {
         let _results = self.metadata.is_file();
         results.get().set_result(_results);
         Ok(())
     }
-    async fn is_symlink(&self) {
+    async fn is_symlink(self: Rc<Self>) {
         let _results = self.metadata.is_symlink();
         results.get().set_result(_results);
         Ok(())
     }
-    async fn len(&self) {
+    async fn len(self: Rc<Self>) {
         let _results = self.metadata.len();
         results.get().set_result(_results);
         Ok(())
     }
-    async fn permissions(&self) {
+    async fn permissions(self: Rc<Self>) {
         let _permissions = self.metadata.permissions();
         results
             .get()
@@ -927,7 +927,7 @@ impl metadata::Server for MetadataImpl {
             }));
         Ok(())
     }
-    async fn modified(&self) {
+    async fn modified(self: Rc<Self>) {
         let Ok(_time) = self.metadata.modified() else {
             return Err(Error::failed(
                 "Failed to access modified field of the metadata".into(),
@@ -938,7 +938,7 @@ impl metadata::Server for MetadataImpl {
             .set_time(capnp_rpc::new_client(SystemTimeImpl { system_time: _time }));
         Ok(())
     }
-    async fn accessed(&self) {
+    async fn accessed(self: Rc<Self>) {
         let Ok(_time) = self.metadata.accessed() else {
             return Err(Error::failed(
                 "Failed to access accessed field of the metadata".into(),
@@ -949,7 +949,7 @@ impl metadata::Server for MetadataImpl {
             .set_time(capnp_rpc::new_client(SystemTimeImpl { system_time: _time }));
         Ok(())
     }
-    async fn created(&self) {
+    async fn created(self: Rc<Self>) {
         let Ok(_time) = self.metadata.created() else {
             return Err(Error::failed(
                 "Failed to access created field of the metadata".into(),
@@ -967,12 +967,12 @@ pub struct PermissionsImpl {
 }
 #[capnproto_rpc(permissions)]
 impl permissions::Server for PermissionsImpl {
-    async fn readonly(&self) {
+    async fn readonly(self: Rc<Self>) {
         let _results = self.permissions.borrow().readonly();
         results.get().set_result(_results);
         Ok(())
     }
-    async fn set_readonly(&self, readonly: bool) {
+    async fn set_readonly(self: Rc<Self>, readonly: bool) {
         self.permissions.borrow_mut().set_readonly(readonly);
         Ok(())
     }
@@ -984,7 +984,7 @@ pub struct TempDirImpl {
 }
 #[capnproto_rpc(temp_dir)]
 impl temp_dir::Server for TempDirImpl {
-    async fn close(&self) {
+    async fn close(self: Rc<Self>) {
         let Some(dir) = self.temp_dir.borrow_mut().take() else {
             return Err(Error::failed("Temp dir already closed".into()));
         };
@@ -993,7 +993,7 @@ impl temp_dir::Server for TempDirImpl {
         };
         Ok(())
     }
-    async fn get_as_dir(&self) {
+    async fn get_as_dir(self: Rc<Self>) {
         let Some(dir) = self.temp_dir.take() else {
             return Err(Error::failed("Temp dir already closed".into()));
         };
@@ -1015,7 +1015,7 @@ pub struct TempFileImpl<'a> {
 }
 #[capnproto_rpc(temp_file)]
 impl temp_file::Server for TempFileImpl<'_> {
-    async fn as_file(&self) {
+    async fn as_file(self: Rc<Self>) {
         let Some(_file) = self.temp_file.borrow_mut().take() else {
             return Err(Error::failed("Temp file already removed".into()));
         };
@@ -1030,7 +1030,7 @@ impl temp_file::Server for TempFileImpl<'_> {
             .set_file(AmbientAuthorityImpl::new_file(&self.ambient, _cloned));
         Ok(())
     }
-    async fn replace(&self, dest: Reader) {
+    async fn replace(self: Rc<Self>, dest: Reader) {
         let dest = dest.to_str()?;
         let Some(temp_file) = self.temp_file.borrow_mut().take() else {
             return Err(Error::failed("Temp file already removed".into()));
@@ -1049,7 +1049,7 @@ pub struct SystemTimeImpl {
 }
 #[capnproto_rpc(system_time)]
 impl system_time::Server for SystemTimeImpl {
-    async fn duration_since(&self, earlier: Capability) {
+    async fn duration_since(self: Rc<Self>, earlier: Capability) {
         let Ok(earlier_duration_since_unix_epoch) = earlier
             .get_duration_since_unix_epoch_request()
             .send()
@@ -1072,7 +1072,7 @@ impl system_time::Server for SystemTimeImpl {
         Ok(())
     }
 
-    async fn checked_add(&self, duration: Reader) {
+    async fn checked_add(self: Rc<Self>, duration: Reader) {
         let secs = duration.get_secs();
         let nanos = duration.get_nanos();
         let duration = Duration::new(secs, nanos);
@@ -1087,7 +1087,7 @@ impl system_time::Server for SystemTimeImpl {
         Ok(())
     }
 
-    async fn checked_sub(&self, duration: Reader) {
+    async fn checked_sub(self: Rc<Self>, duration: Reader) {
         let secs = duration.get_secs();
         let nanos = duration.get_nanos();
         let duration = Duration::new(secs, nanos);
@@ -1102,7 +1102,7 @@ impl system_time::Server for SystemTimeImpl {
         Ok(())
     }
 
-    async fn get_duration_since_unix_epoch(&self) {
+    async fn get_duration_since_unix_epoch(self: Rc<Self>) {
         let Ok(_duration) = self
             .system_time
             .into_std()
@@ -1125,7 +1125,7 @@ pub struct InstantImpl {
 }
 #[capnproto_rpc(instant)]
 impl instant::Server for InstantImpl {
-    async fn duration_since(&self, earlier: Reader) {
+    async fn duration_since(self: Rc<Self>, earlier: Reader) {
         let Some(instant_impl) = self
             .ambient
             .as_ref()
@@ -1144,7 +1144,7 @@ impl instant::Server for InstantImpl {
         response.set_nanos(dur.subsec_nanos());
         Ok(())
     }
-    async fn checked_duration_since(&self, earlier: Capability) {
+    async fn checked_duration_since(self: Rc<Self>, earlier: Capability) {
         let Some(instant_impl) = self
             .ambient
             .as_ref()
@@ -1167,7 +1167,7 @@ impl instant::Server for InstantImpl {
         response.set_nanos(dur.subsec_nanos());
         Ok(())
     }
-    async fn saturating_duration_since(&self, earlier: Capability) {
+    async fn saturating_duration_since(self: Rc<Self>, earlier: Capability) {
         let Some(instant_impl) = self
             .ambient
             .as_ref()
@@ -1186,7 +1186,7 @@ impl instant::Server for InstantImpl {
         response.set_nanos(dur.subsec_nanos());
         Ok(())
     }
-    async fn checked_add(&self, duration: Reader) {
+    async fn checked_add(self: Rc<Self>, duration: Reader) {
         let secs = duration.get_secs();
         let nanos = duration.get_nanos();
         let duration = Duration::new(secs, nanos);
@@ -1198,7 +1198,7 @@ impl instant::Server for InstantImpl {
             .set_instant(AmbientAuthorityImpl::new_instant(&self.ambient, _instant));
         Ok(())
     }
-    async fn checked_sub(&self, duration: Reader) {
+    async fn checked_sub(self: Rc<Self>, duration: Reader) {
         let secs = duration.get_secs();
         let nanos = duration.get_nanos();
         let duration = Duration::new(secs, nanos);
@@ -1220,14 +1220,14 @@ pub struct MonotonicClockImpl {
 }
 #[capnproto_rpc(monotonic_clock)]
 impl monotonic_clock::Server for MonotonicClockImpl {
-    async fn now(&self) {
+    async fn now(self: Rc<Self>) {
         let _instant = self.monotonic_clock.now();
         results
             .get()
             .set_instant(AmbientAuthorityImpl::new_instant(&self.ambient, _instant));
         Ok(())
     }
-    async fn elapsed(&self, instant: Capability) {
+    async fn elapsed(self: Rc<Self>, instant: Capability) {
         let Some(instant_impl) = self
             .ambient
             .as_ref()
@@ -1253,7 +1253,7 @@ pub struct SystemClockImpl {
 }
 #[capnproto_rpc(system_clock)]
 impl system_clock::Server for SystemClockImpl {
-    async fn now(&self) {
+    async fn now(self: Rc<Self>) {
         let _system_time = self.system_clock.now();
         results
             .get()
@@ -1262,7 +1262,7 @@ impl system_clock::Server for SystemClockImpl {
             }));
         Ok(())
     }
-    async fn elapsed(&self, duration_since_unix_epoch: Reader) {
+    async fn elapsed(self: Rc<Self>, duration_since_unix_epoch: Reader) {
         capnp_let!({secs, nanos} = duration_since_unix_epoch);
         //Add duration since unix epoch to unix epoch to reconstruct a system time
         let earlier =
@@ -1283,7 +1283,7 @@ pub struct ProjectDirsImpl {
 }
 #[capnproto_rpc(project_dirs)]
 impl project_dirs::Server for ProjectDirsImpl {
-    async fn cache_dir(&self) {
+    async fn cache_dir(self: Rc<Self>) {
         let Ok(_dir) = self.project_dirs.cache_dir() else {
             return Err(Error::failed("Failed to retrieve cache directory".into()));
         };
@@ -1292,7 +1292,7 @@ impl project_dirs::Server for ProjectDirsImpl {
             .set_dir(AmbientAuthorityImpl::new_dir(&self.ambient, _dir));
         Ok(())
     }
-    async fn config_dir(&self) {
+    async fn config_dir(self: Rc<Self>) {
         let Ok(_dir) = self.project_dirs.config_dir() else {
             return Err(Error::failed("Failed to retrieve config directory".into()));
         };
@@ -1301,7 +1301,7 @@ impl project_dirs::Server for ProjectDirsImpl {
             .set_dir(AmbientAuthorityImpl::new_dir(&self.ambient, _dir));
         Ok(())
     }
-    async fn data_dir(&self) {
+    async fn data_dir(self: Rc<Self>) {
         let Ok(_dir) = self.project_dirs.data_dir() else {
             return Err(Error::failed("Failed to retrieve data directory".into()));
         };
@@ -1310,7 +1310,7 @@ impl project_dirs::Server for ProjectDirsImpl {
             .set_dir(AmbientAuthorityImpl::new_dir(&self.ambient, _dir));
         Ok(())
     }
-    async fn data_local_dir(&self) {
+    async fn data_local_dir(self: Rc<Self>) {
         let Ok(_dir) = self.project_dirs.data_local_dir() else {
             return Err(Error::failed(
                 "Failed to retrieve local data directory".into(),
@@ -1321,7 +1321,7 @@ impl project_dirs::Server for ProjectDirsImpl {
             .set_dir(AmbientAuthorityImpl::new_dir(&self.ambient, _dir));
         Ok(())
     }
-    async fn runtime_dir(&self) {
+    async fn runtime_dir(self: Rc<Self>) {
         let Ok(_dir) = self.project_dirs.runtime_dir() else {
             return Err(Error::failed("Failed to retrieve runtime directory".into()));
         };

--- a/core/src/cell.rs
+++ b/core/src/cell.rs
@@ -8,15 +8,15 @@ use std::rc::Rc;
 
 pub struct SimpleCellImpl {
     id: i64,
-    db: Rc<ServerDispatch<SqliteDatabase>>,
+    db: Rc<SqliteDatabase>,
 }
 
 impl SimpleCellImpl {
-    pub fn new(id: i64, db: Rc<ServerDispatch<SqliteDatabase>>) -> Self {
+    pub fn new(id: i64, db: Rc<SqliteDatabase>) -> Self {
         Self { id, db }
     }
 
-    pub fn init(id: i64, db: Rc<ServerDispatch<SqliteDatabase>>) -> eyre::Result<Self> {
+    pub fn init(id: i64, db: Rc<SqliteDatabase>) -> eyre::Result<Self> {
         // We can't initialize to an empty struct because Cells might not be structs, and we sometimes need to know if we set the cell before.
         //let empty_struct: u64 = 0b0000000000000000000000000000000011111111111111111111111111111100;
         //let segments: &[&[u8]] = &[&empty_struct.to_le_bytes()];
@@ -24,20 +24,19 @@ impl SimpleCellImpl {
         //let message = capnp::message::Reader::new(segment_array, Default::default());
         //let anypointer: capnp::any_pointer::Reader = message.get_root()?;
 
-        db.server.init_state(id)?;
+        db.init_state(id)?;
         Ok(Self { id, db })
     }
 }
 
 #[capnproto_rpc(cell)]
 impl cell::Server<any_pointer> for SimpleCellImpl {
-    async fn get(&self) {
+    async fn get(self: Rc<Self>) {
         let span = tracing::debug_span!("cell", id = self.id);
         let _enter = span.enter();
         tracing::debug!("get()");
         let mut builder = results.get().init_data();
         self.db
-            .server
             .get_state(self.id, builder.reborrow().into())
             .map_err(|e| {
                 eprintln!("CELL GET ERROR: {}", e);
@@ -50,14 +49,14 @@ impl cell::Server<any_pointer> for SimpleCellImpl {
         }
         Ok(())
     }
-    async fn set(&self, data: capnp::any_pointer::Reader) {
+    async fn set(self: Rc<Self>, data: capnp::any_pointer::Reader) {
         // TODO: Cleanup sturdyrefs that end up getting deleted by this operation
 
         let span = tracing::debug_span!("cell", id = self.id);
         let _enter = span.enter();
         tracing::debug!("set()");
 
-        self.db.server.set_state(self.id, data).await.map_err(|e| {
+        self.db.set_state(self.id, data).await.map_err(|e| {
             eprintln!("CELL SET ERROR: {}", e);
             capnp::Error::failed("Could not set data for cell!".into())
         })?;

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -22,44 +22,48 @@ pub type Microseconds = i64; // Microseconds since 1970 (won't overflow for 2000
 /// Internal trait that extends our internal database object with keystone-specific actions
 #[allow(dead_code)]
 pub trait DatabaseExt {
-    fn init(&self) -> Result<()>;
+    fn init(self: &Rc<Self>) -> Result<()>;
 
     fn get_generic<const TABLE: usize>(
-        &self,
+        self: &Rc<Self>,
         id: i64,
         builder: capnp::dynamic_value::Builder<'_>,
     ) -> Result<()>;
 
     fn get_state(
-        &self,
+        self: &Rc<Self>,
         string_index: i64,
         builder: capnp::dynamic_value::Builder<'_>,
     ) -> Result<()>;
 
     async fn set_state<R: SetPointerBuilder + Clone>(
-        &self,
+        self: &Rc<Self>,
         string_index: i64,
         data: R,
     ) -> Result<()>;
 
-    fn init_state(&self, string_index: i64) -> Result<()>;
+    fn init_state(self: &Rc<Self>, string_index: i64) -> Result<()>;
 
     fn get_sturdyref(
-        &self,
+        self: &Rc<Self>,
         sturdy_id: i64,
     ) -> Result<capnp::capability::RemotePromise<restore_results::Owned<any_pointer, any_pointer>>>;
     async fn add_sturdyref<R: SetPointerBuilder + Clone>(
-        &self,
+        self: &Rc<Self>,
         module_id: u64,
         data: R,
         expires: Option<Microseconds>,
     ) -> Result<i64>;
-    fn drop_sturdyref(&self, id: i64) -> Result<()>;
-    fn clean_sturdyrefs(&self, ids: &[i64]) -> Result<()>;
-    async fn add_object<R: SetPointerBuilder + Clone>(&self, data: R) -> Result<i64>;
-    fn get_object(&self, id: i64, builder: capnp::dynamic_value::Builder<'_>) -> Result<()>;
-    fn drop_object(&self, id: i64) -> Result<()>;
-    fn get_string_index(&self, s: &str) -> Result<i64>;
+    fn drop_sturdyref(self: &Rc<Self>, id: i64) -> Result<()>;
+    fn clean_sturdyrefs(self: &Rc<Self>, ids: &[i64]) -> Result<()>;
+    async fn add_object<R: SetPointerBuilder + Clone>(self: &Rc<Self>, data: R) -> Result<i64>;
+    fn get_object(
+        self: &Rc<Self>,
+        id: i64,
+        builder: capnp::dynamic_value::Builder<'_>,
+    ) -> Result<()>;
+    fn drop_object(self: &Rc<Self>, id: i64) -> Result<()>;
+    fn get_string_index(self: &Rc<Self>, s: &str) -> Result<i64>;
 }
 
 // Rust's type system does not like enums in generic constants
@@ -90,7 +94,7 @@ impl AllocatorExt for BufferAllocator {
 impl AllocatorExt for capnp::message::HeapAllocator {}
 
 async fn get_single_segment<'a, R: SetPointerBuilder + Clone>(
-    db: &SqliteDatabase,
+    db: &Rc<SqliteDatabase>,
     alloc: &'a mut impl AllocatorExt,
     data: R,
 ) -> capnp::Result<capnp::message::Builder<&'a mut impl AllocatorExt>> {
@@ -112,10 +116,7 @@ async fn get_single_segment<'a, R: SetPointerBuilder + Clone>(
         builder.set_as(data)?;
     }
 
-    let db_ref = db
-        .this
-        .upgrade()
-        .ok_or(capnp::Error::failed("database doesn't exist".into()))?;
+    let db_ref = db.clone();
     let mut closure = move |hook: Box<dyn ClientHook>| {
         let db_ref_ref = db_ref.clone();
         async move {
@@ -162,7 +163,7 @@ fn drop_generic<const TABLE: usize>(conn: &Connection, id: i64) -> Result<()> {
 }
 
 fn get_replacement(
-    db: &SqliteDatabase,
+    db: &Rc<SqliteDatabase>,
     index: u64,
     mut builder: capnp::any_pointer::Builder,
 ) -> capnp::Result<()> {
@@ -180,7 +181,7 @@ fn cur_time() -> Microseconds {
 }
 
 impl DatabaseExt for SqliteDatabase {
-    fn init(&self) -> Result<()> {
+    fn init(self: &Rc<Self>) -> Result<()> {
         // These three tables look the same but we interact with them slightly differently
         for t in [ROOT_STATES, ROOT_OBJECTS] {
             self.connection.execute(
@@ -223,7 +224,7 @@ impl DatabaseExt for SqliteDatabase {
     }
 
     fn get_generic<const TABLE: usize>(
-        &self,
+        self: &Rc<Self>,
         id: i64,
         builder: capnp::dynamic_value::Builder<'_>,
     ) -> Result<()> {
@@ -267,7 +268,7 @@ impl DatabaseExt for SqliteDatabase {
     }
 
     fn get_state(
-        &self,
+        self: &Rc<Self>,
         string_index: i64,
         builder: capnp::dynamic_value::Builder<'_>,
     ) -> Result<()> {
@@ -275,7 +276,7 @@ impl DatabaseExt for SqliteDatabase {
     }
 
     async fn set_state<R: SetPointerBuilder + Clone>(
-        &self,
+        self: &Rc<Self>,
         string_index: i64,
         data: R,
     ) -> Result<()> {
@@ -305,7 +306,7 @@ impl DatabaseExt for SqliteDatabase {
         Ok(())
     }
 
-    fn init_state(&self, string_index: i64) -> Result<()> {
+    fn init_state(self: &Rc<Self>, string_index: i64) -> Result<()> {
         let slice: &[u8] = &[0; 8];
 
         let call = self
@@ -327,7 +328,7 @@ impl DatabaseExt for SqliteDatabase {
     }
 
     fn get_sturdyref(
-        &self,
+        self: &Rc<Self>,
         id: i64,
     ) -> Result<capnp::capability::RemotePromise<restore_results::Owned<any_pointer, any_pointer>>>
     {
@@ -388,7 +389,7 @@ impl DatabaseExt for SqliteDatabase {
     }
 
     async fn add_sturdyref<R: SetPointerBuilder + Clone>(
-        &self,
+        self: &Rc<Self>,
         module_id: u64,
         data: R,
         expires: Option<Microseconds>,
@@ -433,7 +434,7 @@ impl DatabaseExt for SqliteDatabase {
         Ok(result)
     }
 
-    fn drop_sturdyref(&self, id: i64) -> Result<()> {
+    fn drop_sturdyref(self: &Rc<Self>, id: i64) -> Result<()> {
         expect_change(
             self.connection
                 .prepare_cached(
@@ -448,7 +449,7 @@ impl DatabaseExt for SqliteDatabase {
         )
     }
 
-    fn clean_sturdyrefs(&self, ids: &[i64]) -> Result<()> {
+    fn clean_sturdyrefs(self: &Rc<Self>, ids: &[i64]) -> Result<()> {
         let list: Vec<String> = ids.iter().map(|id| format!("?{}", id)).collect();
 
         expect_change(
@@ -466,7 +467,7 @@ impl DatabaseExt for SqliteDatabase {
         )
     }
 
-    async fn add_object<R: SetPointerBuilder + Clone>(&self, data: R) -> Result<i64> {
+    async fn add_object<R: SetPointerBuilder + Clone>(self: &Rc<Self>, data: R) -> Result<i64> {
         fn inner(conn: &rusqlite::Connection, slice: &[u8]) -> Result<i64> {
             Ok(conn
                 .prepare_cached(
@@ -491,15 +492,19 @@ impl DatabaseExt for SqliteDatabase {
         Ok(result)
     }
 
-    fn get_object(&self, id: i64, builder: capnp::dynamic_value::Builder<'_>) -> Result<()> {
+    fn get_object(
+        self: &Rc<Self>,
+        id: i64,
+        builder: capnp::dynamic_value::Builder<'_>,
+    ) -> Result<()> {
         self.get_generic::<ROOT_OBJECTS>(id, builder)
     }
 
-    fn drop_object(&self, id: i64) -> Result<()> {
+    fn drop_object(self: &Rc<Self>, id: i64) -> Result<()> {
         drop_generic::<ROOT_OBJECTS>(&self.connection, id)
     }
 
-    fn get_string_index(&self, s: &str) -> Result<i64> {
+    fn get_string_index(self: &Rc<Self>, s: &str) -> Result<i64> {
         self.connection
             .prepare_cached("INSERT OR IGNORE INTO stringmap (string) VALUES (?1)")?
             .execute(params![s])?;
@@ -529,9 +534,9 @@ fn create(path: impl AsRef<Path>) -> Result<Connection, rusqlite::Error> {
 
 pub fn open_database<DB: DatabaseExt>(
     path: impl AsRef<Path>,
-    f: impl Fn(Connection) -> capnp::Result<Rc<crate::sqlite_capnp::root::ServerDispatch<DB>>>,
+    f: impl Fn(Connection) -> capnp::Result<Rc<DB>>,
     options: OpenOptions,
-) -> Result<Rc<crate::sqlite_capnp::root::ServerDispatch<DB>>> {
+) -> Result<Rc<DB>> {
     let span = tracing::span!(tracing::Level::DEBUG, "database::open_database", path = ?path.as_ref(), options = ?options);
     let _enter = span.enter();
     match options {
@@ -549,7 +554,7 @@ pub fn open_database<DB: DatabaseExt>(
 
             let r = f(Connection::open_with_flags(path, flags)?)?;
             if create {
-                r.server.init()?;
+                r.init()?;
             }
             Ok(r)
         }
@@ -559,7 +564,7 @@ pub fn open_database<DB: DatabaseExt>(
                 file.set_len(0)?;
             }
             let r = f(create(path)?)?;
-            r.server.init()?;
+            r.init()?;
             Ok(r)
         }
         OpenOptions::ReadWrite => Ok(f(Connection::open_with_flags(

--- a/core/src/http/https.rs
+++ b/core/src/http/https.rs
@@ -4,6 +4,7 @@ use capnp_macros::capnproto_rpc;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::{connect::HttpConnector, Client as HttpClient};
 use hyper_util::rt::TokioExecutor;
+use std::rc::Rc;
 
 pub struct HttpsImpl {
     https_client: HttpClient<HttpsConnector<HttpConnector>, String>,
@@ -18,7 +19,7 @@ impl HttpsImpl {
 }
 #[capnproto_rpc(Https)]
 impl Https::Server for HttpsImpl {
-    async fn domain(&self, name: capnp::text::Reader) {
+    async fn domain(self: Rc<Self>, name: capnp::text::Reader) {
         let domain_impl = DomainImpl::new(name.to_str()?, self.https_client.clone())?;
         let domain: Domain::Client = capnp_rpc::new_client(domain_impl);
         results.get().set_result(domain);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -142,9 +142,7 @@ pub async fn start<
     });
 
     let module_client: module_start::Client<Config, API> =
-        capnp::capability::FromClientHook::new(Box::new(capnp_rpc::local::Client::new(
-            module_start::Client::<Config, API>::from_rc(module_impl.clone()),
-        )));
+        capnp_rpc::new_client_from_rc(module_impl.clone());
 
     let network = twoparty::VatNetwork::new(
         reader,

--- a/core/src/proxy.rs
+++ b/core/src/proxy.rs
@@ -28,6 +28,7 @@ impl<'a> FromPointerReader<'a> for GetPointerReader<'a> {
     }
 }
 
+#[derive(Clone)]
 pub struct ProxyServer {
     pub target: Client,
     pub set: Rc<RefCell<CapSet>>,
@@ -53,7 +54,7 @@ impl ProxyServer {
 
 impl Server for ProxyServer {
     async fn dispatch_call(
-        &self,
+        self,
         interface_id: u64,
         method_id: u16,
         params: Params<capnp::any_pointer::Owned>,
@@ -135,5 +136,9 @@ impl Server for ProxyServer {
         let response = request.send().promise.await?;
         results.hook.get()?.set_as(response.hook.get()?)?;
         Ok(())
+    }
+
+    fn get_ptr(&self) -> usize {
+        self.target.hook.get_ptr()
     }
 }

--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -89,7 +89,7 @@ impl TimeSource for () {
 }
 
 pub struct Scheduler {
-    db: Rc<ServerDispatch<SqliteDatabase>>,
+    db: Rc<SqliteDatabase>,
     signal: tokio::sync::mpsc::Sender<Queue>,
 }
 
@@ -149,7 +149,7 @@ fn to_datetime(tz: &Tz, timestamp: i64) -> Result<DateTime<Tz>> {
 impl Scheduler {
     #[allow(clippy::too_many_arguments)]
     pub async fn repeat(
-        db: &Rc<ServerDispatch<SqliteDatabase>>,
+        db: &Rc<SqliteDatabase>,
         timestamp: i64,
         every_months: u32,
         every_days: u32,
@@ -193,7 +193,7 @@ impl Scheduler {
     }
 
     pub async fn run(
-        db: Rc<ServerDispatch<SqliteDatabase>>,
+        db: Rc<SqliteDatabase>,
         action: i64,
     ) -> Result<crate::scheduler_capnp::action::Client> {
         let sturdyref = db.get_sturdyref(action)?;
@@ -208,7 +208,7 @@ impl Scheduler {
     }
 
     async fn run_and_save(
-        db: &Rc<ServerDispatch<SqliteDatabase>>,
+        db: &Rc<SqliteDatabase>,
         id: i64,
         action: i64,
         update: &mut CachedStatement<'_>,
@@ -226,16 +226,9 @@ impl Scheduler {
         Err(r)
     }
 
-    async fn catchup(
-        db: Rc<ServerDispatch<SqliteDatabase>>,
-        miss: MissBehavior,
-        id: i64,
-        count: i64,
-        action: i64,
-    ) {
+    async fn catchup(db: Rc<SqliteDatabase>, miss: MissBehavior, id: i64, count: i64, action: i64) {
         if miss != MissBehavior::None {
             let mut update = match db
-                .server
                 .connection
                 .prepare_cached("UPDATE scheduler SET action = ?2 WHERE id = ?1")
             {
@@ -271,11 +264,11 @@ impl Scheduler {
 
     #[allow(private_bounds)]
     pub fn new<TS: TimeSource + 'static>(
-        db: Rc<ServerDispatch<SqliteDatabase>>,
+        db: Rc<SqliteDatabase>,
         mut ts: TS,
     ) -> Result<(Self, impl Future<Output = Result<()>>)> {
         // Prep database
-        db.server.connection.execute(
+        db.connection.execute(
             "
 CREATE TABLE IF NOT EXISTS scheduler (
   id           INTEGER PRIMARY KEY,
@@ -298,19 +291,16 @@ CREATE TABLE IF NOT EXISTS scheduler (
 
         // This absolutely must be in a spawn() call of some kind because a multithreaded runtime must be able to give it as much wakeup granularity as possible.
         let fut = async move {
-            let mut get_range = db.server.connection.prepare_cached(
+            let mut get_range = db.connection.prepare_cached(
                 "SELECT id, timestamp, action, every_months, every_days, every_hours, every_millis, tz, repeat FROM scheduler WHERE timestamp <= ?1",
             )?;
             let mut remove = db
-                .server
                 .connection
                 .prepare_cached("DELETE FROM scheduler WHERE id = ?1")?;
             let mut set = db
-                .server
                 .connection
                 .prepare_cached("UPDATE scheduler SET timestamp = ?2 WHERE id = ?1")?;
             let mut get_time = db
-                .server
                 .connection
                 .prepare_cached("SELECT timestamp FROM scheduler ORDER BY timestamp ASC LIMIT 1")?;
 
@@ -515,15 +505,12 @@ use crate::scheduler_capnp::root;
 
 #[capnproto_rpc(registration)]
 impl registration::Server for Registration {
-    async fn cancel(&self) {
+    async fn cancel(self: Rc<Self>) {
         self.signal.send(Queue::Cancel(self.id)).await.to_capnp()
     }
 }
 
-async fn db_save_action(
-    db: Rc<ServerDispatch<SqliteDatabase>>,
-    hook: Box<dyn ClientHook>,
-) -> capnp::Result<i64> {
+async fn db_save_action(db: Rc<SqliteDatabase>, hook: Box<dyn ClientHook>) -> capnp::Result<i64> {
     let saveable: crate::storage_capnp::saveable::Client<any_pointer> =
         capnp::capability::FromClientHook::new(hook);
     let response = saveable.save_request().send().promise.await?;
@@ -533,7 +520,7 @@ async fn db_save_action(
 
 impl root::Server for Scheduler {
     async fn once_(
-        &self,
+        self: Rc<Self>,
         params: root::OnceParams,
         mut results: root::OnceResults,
     ) -> Result<(), ::capnp::Error> {
@@ -569,7 +556,7 @@ impl root::Server for Scheduler {
     }
 
     async fn every(
-        &self,
+        self: Rc<Self>,
         params: root::EveryParams,
         mut results: root::EveryResults,
     ) -> Result<(), ::capnp::Error> {
@@ -608,7 +595,7 @@ impl root::Server for Scheduler {
     }
 
     async fn complex(
-        &self,
+        self: Rc<Self>,
         params: root::ComplexParams,
         mut results: root::ComplexResults,
     ) -> Result<(), ::capnp::Error> {
@@ -759,13 +746,12 @@ mod tests {
     }
 
     struct TestModule {
-        db: Rc<ServerDispatch<SqliteDatabase>>,
+        db: Rc<SqliteDatabase>,
         actions: RefCell<HashMap<String, (i32, oneshot::Sender<()>)>>,
-        this: std::rc::Weak<restore::ServerDispatch<TestModule, any_pointer>>, // TODO: Remove once we have access to Rc<Self>
     }
 
     struct TestRepeatCallback {
-        db: Rc<ServerDispatch<SqliteDatabase>>,
+        db: Rc<SqliteDatabase>,
     }
 
     #[capnproto_rpc(repeat_callback)]
@@ -810,7 +796,7 @@ mod tests {
 
     impl restore::Server<any_pointer> for TestModule {
         async fn restore(
-            &self,
+            self: Rc<Self>,
             params: restore::RestoreParams<any_pointer>,
             mut results: restore::RestoreResults<any_pointer>,
         ) -> Result<(), ::capnp::Error> {
@@ -840,10 +826,7 @@ mod tests {
                     send: send.into(),
                     key,
                     count: count.into(),
-                    parent: self
-                        .this
-                        .upgrade()
-                        .ok_or(capnp::Error::failed("Failed to upgrade self ref".into()))?,
+                    parent: self.clone(),
                 });
 
                 results
@@ -870,17 +853,14 @@ mod tests {
             crate::database::OpenOptions::Create,
         )?;
 
-        let module: Rc<restore::ServerDispatch<TestModule, any_pointer>> = Rc::new_cyclic(|w| {
-            restore::Client::from_server(TestModule {
-                db: db.clone(),
-                actions: RefCell::new(HashMap::new()),
-                this: w.clone(),
-            })
+        let module: Rc<TestModule> = Rc::new(TestModule {
+            db: db.clone(),
+            actions: RefCell::new(HashMap::new()),
         });
 
         db.clients.borrow_mut().insert(
             1,
-            capnp_rpc::local::Client::from_rc(module.clone()).add_ref(),
+            capnp_rpc::local::Client::new(restore::Client::from_rc(module.clone())).add_ref(),
         );
         let (sleep, waker) = mpsc::channel(1);
         let (time, now) = mpsc::channel(1);

--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -149,7 +149,7 @@ fn to_datetime(tz: &Tz, timestamp: i64) -> Result<DateTime<Tz>> {
 impl Scheduler {
     #[allow(clippy::too_many_arguments)]
     pub async fn repeat(
-        db: &Rc<SqliteDatabase>,
+        db: &SqliteDatabase,
         timestamp: i64,
         every_months: u32,
         every_days: u32,
@@ -330,7 +330,7 @@ CREATE TABLE IF NOT EXISTS scheduler (
                         while next <= now {
                             count += 1;
                             next = Self::repeat(
-                                &db,
+                                db.as_ref(),
                                 next,
                                 every_months as u32,
                                 every_days as u32,

--- a/core/src/sqlite.rs
+++ b/core/src/sqlite.rs
@@ -2738,12 +2738,14 @@ mod tests {
     #[tokio::test]
     async fn test_sqlite() -> eyre::Result<()> {
         let db_path = NamedTempFile::new().unwrap().into_temp_path();
-        let hook = capnp_rpc::local::Client::from_rc(SqliteDatabase::new(
-            db_path.to_path_buf(),
-            OpenFlags::default(),
-            Default::default(),
-            Default::default(),
-        )?)
+        let hook = capnp_rpc::local::Client::new(crate::sqlite_capnp::root::Client::from_server(
+            SqliteDatabase::new(
+                db_path.to_path_buf(),
+                OpenFlags::default(),
+                Default::default(),
+                Default::default(),
+            )?,
+        ))
         .add_ref();
         let client: add_d_b::Client = FromClientHook::new(hook);
 
@@ -2946,12 +2948,14 @@ mod tests {
     #[tokio::test]
     async fn test_parsing_sql() -> eyre::Result<()> {
         let db_path = NamedTempFile::new().unwrap().into_temp_path();
-        let hook = capnp_rpc::local::Client::from_rc(SqliteDatabase::new(
-            db_path.to_path_buf(),
-            OpenFlags::default(),
-            Default::default(),
-            Default::default(),
-        )?)
+        let hook = capnp_rpc::local::Client::new(crate::sqlite_capnp::root::Client::from_server(
+            SqliteDatabase::new(
+                db_path.to_path_buf(),
+                OpenFlags::default(),
+                Default::default(),
+                Default::default(),
+            )?,
+        ))
         .add_ref();
         let client: add_d_b::Client = FromClientHook::new(hook);
 

--- a/core/src/sturdyref.rs
+++ b/core/src/sturdyref.rs
@@ -1,7 +1,6 @@
 use crate::database::DatabaseExt;
 use crate::keystone::CapnpResult;
 use crate::sqlite::SqliteDatabase;
-use crate::sqlite_capnp::root::ServerDispatch;
 use crate::storage_capnp::sturdy_ref;
 use capnp::any_pointer::Owned as any_pointer;
 use capnp::traits::SetPointerBuilder;
@@ -9,14 +8,14 @@ use std::rc::Rc;
 
 pub struct SturdyRefImpl {
     id: i64,
-    db: Rc<ServerDispatch<SqliteDatabase>>,
+    db: Rc<SqliteDatabase>,
 }
 
 impl SturdyRefImpl {
     pub async fn init<'a, R: SetPointerBuilder + Clone>(
         module_id: u64,
         data: R,
-        db: Rc<ServerDispatch<SqliteDatabase>>,
+        db: Rc<SqliteDatabase>,
     ) -> eyre::Result<Self> {
         let id = db.add_sturdyref(module_id, data, None).await.to_capnp()?;
 
@@ -30,7 +29,7 @@ impl SturdyRefImpl {
 
 impl sturdy_ref::Server<any_pointer> for SturdyRefImpl {
     async fn restore(
-        &self,
+        self: Rc<Self>,
         _: sturdy_ref::RestoreParams<any_pointer>,
         mut results: sturdy_ref::RestoreResults<any_pointer>,
     ) -> Result<(), ::capnp::Error> {

--- a/examples/complex-config/main.rs
+++ b/examples/complex-config/main.rs
@@ -8,6 +8,7 @@ use capnp::traits::Imbue;
 use capnp::traits::ImbueMut;
 use capnp::traits::Owned;
 use capnp_macros::capnproto_rpc;
+use std::rc::Rc;
 
 pub struct ComplexConfigImpl {
     pub msg: capnp::message::Builder<capnp::message::HeapAllocator>,
@@ -16,7 +17,7 @@ pub struct ComplexConfigImpl {
 
 #[capnproto_rpc(root)]
 impl root::Server for ComplexConfigImpl {
-    async fn get_config(&self) -> Result<(), ::capnp::Error> {
+    async fn get_config(self: Rc<Self>) -> Result<(), ::capnp::Error> {
         tracing::debug!("get_config was called! {:?}", self.caps);
 
         let mut reader: config::Reader = self.msg.get_root_as_reader()?;

--- a/examples/hello-world/main.rs
+++ b/examples/hello-world/main.rs
@@ -3,6 +3,7 @@ include!(concat!(env!("OUT_DIR"), "/capnproto.rs"));
 use crate::hello_world_capnp::root;
 use capnp::any_pointer::Owned as any_pointer;
 use capnp_macros::capnproto_rpc;
+use std::rc::Rc;
 
 pub struct HelloWorldImpl {
     pub greeting: String,
@@ -10,7 +11,7 @@ pub struct HelloWorldImpl {
 
 #[capnproto_rpc(root)]
 impl root::Server for HelloWorldImpl {
-    async fn say_hello(&self, request: Reader) -> capnp::Result<Self> {
+    async fn say_hello(self: Rc<Self>, request: Reader) -> capnp::Result<Self> {
         tracing::debug!("say_hello was called!");
         let name = request.get_name()?.to_str()?;
         let greet = self.greeting.as_str();

--- a/examples/indirect-world/indirect_world.rs
+++ b/examples/indirect-world/indirect_world.rs
@@ -1,6 +1,7 @@
 use crate::indirect_world_capnp::root;
 use capnp::any_pointer::Owned as any_pointer;
 use capnp_macros::capnproto_rpc;
+use std::rc::Rc;
 
 pub struct IndirectWorldImpl {
     pub hello_client: hello_world::hello_world_capnp::root::Client,
@@ -8,7 +9,7 @@ pub struct IndirectWorldImpl {
 
 #[capnproto_rpc(root)]
 impl root::Server for IndirectWorldImpl {
-    async fn say_hello(&self, request: Reader) -> Result<(), ::capnp::Error> {
+    async fn say_hello(self: Rc<Self>, request: Reader) -> Result<(), ::capnp::Error> {
         tracing::debug!("say_hello was called!");
 
         let mut sayhello = self.hello_client.say_hello_request();

--- a/examples/sqlite-usage/main.rs
+++ b/examples/sqlite-usage/main.rs
@@ -21,6 +21,7 @@ use keystone::sqlite_capnp::table_field;
 use keystone::sqlite_capnp::table_or_subquery;
 use keystone::storage_capnp::cell;
 use sqlite_usage_capnp::root;
+use std::rc::Rc;
 
 pub struct SqliteUsageImpl {
     pub outer: cell::Client<keystone::sqlite_capnp::table_ref::Owned>,
@@ -30,7 +31,7 @@ pub struct SqliteUsageImpl {
 
 #[capnproto_rpc(root)]
 impl root::Server for SqliteUsageImpl {
-    async fn echo_alphabetical(&self, request: Reader) -> Result<(), ::capnp::Error> {
+    async fn echo_alphabetical(self: Rc<Self>, request: Reader) -> Result<(), ::capnp::Error> {
         tracing::debug!("echo_alphabetical was called!");
 
         let res = self

--- a/examples/stateful/stateful.rs
+++ b/examples/stateful/stateful.rs
@@ -2,6 +2,7 @@ use crate::stateful_capnp::my_state;
 use crate::stateful_capnp::root;
 use capnp_macros::capnproto_rpc;
 use keystone::storage_capnp::cell;
+use std::rc::Rc;
 
 pub struct StatefulImpl {
     pub echo_word: String,
@@ -10,7 +11,7 @@ pub struct StatefulImpl {
 
 #[capnproto_rpc(root)]
 impl root::Server for StatefulImpl {
-    async fn echo_last(&self, request: Reader) -> Result<(), ::capnp::Error> {
+    async fn echo_last(self: Rc<Self>, request: Reader) -> Result<(), ::capnp::Error> {
         tracing::debug!("echo_last was called!");
         let name = request.get_name()?.to_str()?;
         let prev_request = self.echo_last.get_request().send();


### PR DESCRIPTION
This refactors keystone to take advantage of capstone-rs exposing [self as Rc<Self>](https://github.com/Fundament-Software/capstone-rs/pull/62), which lets us get rid of a bunch of self-referential nonsense.

This PR will not build until both capstone-rs and Caplog are updated.